### PR TITLE
Non jupyter chrome canary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,14 @@
 #.ipynb
 .ipynb_checkpoints
 
-# jetbrains stuff
-.idea
+# jetbrains ide stuff
 *.iml
+.idea/
+
+# vscode ide stuff
+*.code-workspace
+.history
+.vscode
 
 # old or backup files
 bak_*

--- a/install
+++ b/install
@@ -3,11 +3,12 @@
 shopt -s expand_aliases
 set -e
 
-# set up command line parsing via getopts
 # Usage info
+# dev-mode-only -t switch omitted from printed help:
+#     -t    Download image file to CWD instead of a tmp dir (the default behavior).
 show_help() {
 cat << EOF
-Usage: ${0##*/} [-cd]
+Usage: ${0##*/} [-hd]
 Install the Jupyter.app
 
     -h    Display this help and exit.
@@ -25,6 +26,7 @@ OPTIND=1
 # Resetting OPTIND is necessary if getopts was used previously in the script.
 # It is a good idea to make OPTIND local if you process options in a function.
 
+# set up command line parsing via getopts
 while getopts hdtr opt; do
     case $opt in
         h)  show_help
@@ -171,42 +173,6 @@ dryecho cp "${ABS_ICONS_SRC}" "${ABS_ICONS}"
 printf "done\n\n"
 
 
-# rename the actual exe
-printf "renaming app executable...\n"
-dryecho mv "${ABS_APP_BIN_SRC}" "${ABS_APP_BIN}"
-printf "done\n\n"
-
-
-# copy over the outer wrapper script, which handles the terminal window
-printf "copying outer wrapper script over to app...\n"
-dryecho cp "${ABS_OUTER_WRAP_SRC}" "${ABS_OUTER_WRAP}"
-printf "setting vars in outer wrapper script...\n"
-sedvar "${ABS_OUTER_WRAP}" TERM_NAME ABS_MID_WRAP
-printf "done\n\n"
-
-
-# copy over the mid wrapper script, which launches the jupyter server
-printf "copying mid wrapper script over to app...\n"
-dryecho cp "${ABS_MID_WRAP_SRC}" "${ABS_MID_WRAP}"
-printf "setting vars in mid wrapper script...\n"
-sedvar "${ABS_MID_WRAP}" VIRTUAL_ENV JUPYTER_BIN JUPYTER_CMD JUPYTER_NOTEBOOK_DIR ABS_INNER_WRAP BROWSER_CMD
-printf "done\n\n"
-
-
-# copy over the inner wrapper script, which automatically passes certain arguments to the chrome bin
-printf "copying inner wrapper script over to app...\n"
-dryecho cp "${ABS_INNER_WRAP_SRC}" "${ABS_INNER_WRAP}"
-printf "setting vars in inner wrapper script...\n"
-sedvar "${ABS_INNER_WRAP}" ABS_APP_SUPPORT_PATH ABS_APP_BIN
-printf "done\n\n"
-
-
-# modify the app's plist's exe to point to the script we just copied over
-printf "Modifying app's Info.plist to point to executable scripts...\n"
-dryecho plutil -replace CFBundleExecutable -string "${APP_NAME}" "${ABS_CONTENTS}/Info.plist"
-printf "done\n\n"
-
-
 # modify the app's plist's bundle name
 printf "Modifying app's Info.plist...\n"
 dryecho plutil -replace CFBundleDisplayName -string "${APP_NAME}"  "${ABS_CONTENTS}/Info.plist"
@@ -237,5 +203,42 @@ if [ "$EXTENSIONS" = true ]; then
     for extjson in ${ABS_EXTENSION_JSON_SRC}; do
         dryecho cp "${extjson}" "${ABS_EXTENSION_JSON}"
     done
+    printf "done\n\n"
+fi
+
+if [ "$JUPYTER_WRAP" = true ]; then
+    # rename the actual exe
+    printf "renaming app executable...\n"
+    dryecho mv "${ABS_APP_BIN_SRC}" "${ABS_APP_BIN}"
+    printf "done\n\n"
+
+
+    # copy over the outer wrapper script, which handles the terminal window
+    printf "copying outer wrapper script over to app...\n"
+    dryecho cp "${ABS_OUTER_WRAP_SRC}" "${ABS_OUTER_WRAP}"
+    printf "setting vars in outer wrapper script...\n"
+    sedvar "${ABS_OUTER_WRAP}" TERM_NAME ABS_MID_WRAP
+    printf "done\n\n"
+
+
+    # copy over the mid wrapper script, which launches the jupyter server
+    printf "copying mid wrapper script over to app...\n"
+    dryecho cp "${ABS_MID_WRAP_SRC}" "${ABS_MID_WRAP}"
+    printf "setting vars in mid wrapper script...\n"
+    sedvar "${ABS_MID_WRAP}" VIRTUAL_ENV JUPYTER_BIN JUPYTER_CMD JUPYTER_NOTEBOOK_DIR ABS_INNER_WRAP BROWSER_CMD
+    printf "done\n\n"
+
+
+    # copy over the inner wrapper script, which automatically passes certain arguments to the chrome bin
+    printf "copying inner wrapper script over to app...\n"
+    dryecho cp "${ABS_INNER_WRAP_SRC}" "${ABS_INNER_WRAP}"
+    printf "setting vars in inner wrapper script...\n"
+    sedvar "${ABS_INNER_WRAP}" ABS_APP_SUPPORT_PATH ABS_APP_BIN
+    printf "done\n\n"
+
+
+    # modify the app's plist's exe to point to the script we just copied over
+    printf "Modifying app's Info.plist to point to executable scripts...\n"
+    dryecho plutil -replace CFBundleExecutable -string "${APP_NAME}" "${ABS_CONTENTS}/Info.plist"
     printf "done\n\n"
 fi

--- a/install
+++ b/install
@@ -167,9 +167,9 @@ dryecho rm -r "${temp}"
 printf "done\n\n"
 
 
-# change the icon
-printf "changing app icon to jupyter...\n"
-dryecho cp "${ABS_ICONS_SRC}" "${ABS_ICONS}"
+# rename the actual exe
+printf "renaming app executable...\n"
+dryecho mv "${ABS_APP_BIN_SRC}" "${ABS_APP_BIN}"
 printf "done\n\n"
 
 
@@ -195,21 +195,16 @@ dryecho sedStringsFile CFBundleName "${APP_NAME}" ${INFO_PLIST_STRINGS}
 printf "done\n\n"
 
 
-# optionally install any extension manifests to the new Chrome instance's 'Application Support' dir
-if [ "$EXTENSIONS" = true ]; then
-    printf "Adding extension manifests to \"${ABS_EXTENSION_JSON}\"...\n"
-    # create the External Extensions dir if it doesn't exist
-    dryecho mkdir -p "${ABS_EXTENSION_JSON}"
-    for extjson in ${ABS_EXTENSION_JSON_SRC}; do
-        dryecho cp "${extjson}" "${ABS_EXTENSION_JSON}"
-    done
-    printf "done\n\n"
-fi
+# modify the app's plist's exe to point to the script we just copied over
+printf "Modifying app's Info.plist to point to executable scripts...\n"
+dryecho plutil -replace CFBundleExecutable -string "${APP_NAME}" "${ABS_CONTENTS}/Info.plist"
+printf "done\n\n"
+
 
 if [ "$JUPYTER_WRAP" = true ]; then
-    # rename the actual exe
-    printf "renaming app executable...\n"
-    dryecho mv "${ABS_APP_BIN_SRC}" "${ABS_APP_BIN}"
+    # change the icon for some good jupyter style
+    printf "changing app icon to jupyter...\n"
+    dryecho cp "${ABS_ICONS_SRC}" "${ABS_ICONS}"
     printf "done\n\n"
 
 
@@ -235,10 +230,21 @@ if [ "$JUPYTER_WRAP" = true ]; then
     printf "setting vars in inner wrapper script...\n"
     sedvar "${ABS_INNER_WRAP}" ABS_APP_SUPPORT_PATH ABS_APP_BIN
     printf "done\n\n"
+fi
 
 
-    # modify the app's plist's exe to point to the script we just copied over
-    printf "Modifying app's Info.plist to point to executable scripts...\n"
-    dryecho plutil -replace CFBundleExecutable -string "${APP_NAME}" "${ABS_CONTENTS}/Info.plist"
+# optionally install any extension manifests to the new Chrome instance's 'Application Support' dir
+if [ "$EXTENSIONS" = true ]; then
+    printf "Adding extension manifests to \"${ABS_EXTENSION_JSON}\"...\n"
+    # create the External Extensions dir if it doesn't exist
+    dryecho mkdir -p "${ABS_EXTENSION_JSON}"
+    for extjson in ${ABS_EXTENSION_JSON_SRC}; do
+        dryecho cp "${extjson}" "${ABS_EXTENSION_JSON}"
+    done
     printf "done\n\n"
 fi
+
+
+## possible extra commands needed for chrome_canary install
+# xattr -lr /Applications/Chrome-canary.app/
+# sudo codesign -f -s - /Applications/Chrome-canary.app/Contents/MacOS/Chrome-canary

--- a/install.conf
+++ b/install.conf
@@ -33,6 +33,9 @@ JUPYTER_BIN=jupyter
 # the root dir in your file system that you want jupyter to start in
 JUPYTER_NOTEBOOK_DIR='${HOME}'
 
+# if false, skip the steps that alter the exe to point to a jupyter process
+JUPYTER_WRAP=true
+
 # if true, the browser will be launched in app mode, hiding the url bar
 HIDE_URL_BAR=true
 

--- a/resource/globals
+++ b/resource/globals
@@ -25,10 +25,12 @@ SCRIPT="script"
 ICNS=app.icns
 if [ "${APP_BASE}" = "chrome" ]; then
     APP_BASE_BIN="Google Chrome"
+elif [ "${APP_BASE}" = "chrome_canary" ]; then
+    APP_BASE_BIN="Google Chrome Canary"
 elif [ "${APP_BASE}" = "chromium" ]; then
     APP_BASE_BIN="Chromium"
 else
-    echo "APP_BASE is ${APP_BASE}, must be one of: chrome | chromium" 1>&2
+    echo "APP_BASE is ${APP_BASE}, must be one of: chrome | chrome_canary | chromium" 1>&2
     exit 1
 fi
 APP_BIN="${APP_NAME}_bin"

--- a/script/download/chrome.sh
+++ b/script/download/chrome.sh
@@ -12,5 +12,5 @@ if [ "$2" = dryrun ]; then
 fi
 
 printf "downloading vanilla google chrome...\n"
-dryecho curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg -o "${dmgPath}.dmg"
+dryecho curl https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg -o "${dmgPath}"
 printf "done\n\n"

--- a/script/download/chrome_canary.sh
+++ b/script/download/chrome_canary.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+shopt -s expand_aliases
+set -e
+
+dmgPath=$1
+
+# define the dryrun echo command as appropriate
+alias dryecho=
+if [ "$2" = dryrun ]; then
+    alias dryecho='echo'
+fi
+
+# fonts of chrome url knowledge:
+# https://www.google.com/chrome/assets/common/js/chrome-installer.min.js
+# https://superuser.com/a/1067482
+
+printf "downloading google chrome canary...\n"
+dryecho curl https://dl.google.com/release2/q/canary/googlechrome.dmg -o "${dmgPath}"
+printf "done\n\n"


### PR DESCRIPTION
- Support for chrome_canary as an app base (mostly works)
- JUPTYER_WRAP config dir. Default "true". If not "true", don't wrap browser startup/shutdown in juptyer startup/shutdown (in other words you just get a browser with the non-jupyter-specific hacks from this app)